### PR TITLE
Update Uruguay platform configuration link and remove collaborator name

### DIFF
--- a/pages/about.py
+++ b/pages/about.py
@@ -174,12 +174,11 @@ def main():
         st.markdown("""
         - Tarcisio Philips
         - Vitória Lacerda
-        - Elton Vicente Escobar Silva
+        - Pedro Elardenberg Sousa e Souza
         """)
 
     with col2:
         st.markdown("""
-        - Pedro Elardenberg Sousa e Souza
         - André Canal
         - Lucas Ribeiro
         """)

--- a/pages/uy_about.py
+++ b/pages/uy_about.py
@@ -20,7 +20,7 @@ translations = {
             "não só a mitigação de riscos, mas também um planejamento superior do uso da água."
         ),
         "link_label": "Link para plataforma original",
-        "link": None
+        "link": "Link para configuração da plataforma original"
     },
     "English": {
         "title": "MORIS River Monitoring and Visualization Platform",
@@ -36,7 +36,7 @@ translations = {
             "of water use under normal conditions."
         ),
         "link_label": "Original platform link",
-        "link": None
+        "link": "Link to the original platform setup"
     },
     "Español": {
         "title": "Plataforma de Monitoreo y Visualización de los Ríos MORIS",
@@ -53,7 +53,7 @@ translations = {
             "planificación del uso del agua en condiciones normales."
         ),
         "link_label": "Enlace a la plataforma original",
-        "link": None
+        "link": "Link para la configuración de la plataforma original"
     }
 }
 
@@ -66,7 +66,13 @@ st.write(t["body2"])
 
 st.markdown("---")
 
-if t["link"]:
-    st.markdown(f"🔗 [{t['link_label']}]({t['link']})")
-else:
-    st.markdown("🔗 **Link para plataforma original:** em breve")
+# if t["link"]:
+#     st.markdown(f"🔗 [{t['link_label']}]({t['link']})")
+# else:
+    # st.markdown("🔗 **Link para plataforma original:** https://drive.google.com/drive/folders/1ooidwueE6fabWDCi7B_V52saJSesMMmK?usp=drive_link")
+
+# link externo (Streamlit + URL correta)
+
+st.markdown(
+    f"🔗 [{translations[lang]['link']}]({ 'https://drive.google.com/drive/folders/1ooidwueE6fabWDCi7B_V52saJSesMMmK?usp=drive_link' })"
+)


### PR DESCRIPTION
- Added the link to the original platform configuration related to Uruguay.
- Removed the name of one collaborator from the documentation.